### PR TITLE
Add common response handling

### DIFF
--- a/handlers/v1/actor_handler.go
+++ b/handlers/v1/actor_handler.go
@@ -1,8 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/go-chi/chi"
@@ -18,21 +16,6 @@ type ActorHandler struct {
 // ServeHTTP handles an HTTP request.
 func (a *ActorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	actorId := chi.URLParam(r, "actorId")
-	var marshaled []byte
-
 	actor, err := a.Callback(actorId)
-	if err != nil {
-		marshaled = types.MarshalErrors([]string{err.Error()})
-	} else {
-		actor.Kind = "actor"
-		if marshaled, err = json.Marshal(actor); err != nil {
-			log.Error(err)
-			return
-		}
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _,err = fmt.Fprint(w, string(marshaled[:])); err != nil {
-		log.Error(err)
-	}
+	Respond(w, actor, err)
 }

--- a/handlers/v1/actor_handler_test.go
+++ b/handlers/v1/actor_handler_test.go
@@ -19,7 +19,7 @@ func TestActor_ServeHTTP(t *testing.T) {
 		fa := types.Actor{
 			ActorType: "account",
 			Address:   "abcd123",
-			Balance:   *big.NewInt(600),
+			Balance:   big.NewInt(600),
 			Code:      test.RequireTestCID(t, []byte("anything")),
 			Nonce:     123434,
 		}

--- a/handlers/v1/block_handler.go
+++ b/handlers/v1/block_handler.go
@@ -1,8 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/go-chi/chi"
@@ -17,22 +15,7 @@ type BlockHandler struct {
 
 // ServeHTTP handles an HTTP request.
 func (bhh *BlockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	var marshaled []byte
 	blockId := chi.URLParam(r, "actorId")
-
 	block, err := bhh.Callback(blockId)
-	if err != nil {
-		marshaled = types.MarshalErrors([]string{err.Error()})
-	} else {
-		block.Kind = "block"
-		block.Header.Kind = "blockHeader"
-		if marshaled, err = json.Marshal(block); err != nil {
-			log.Error(err)
-			return
-		}
-	}
-	w.WriteHeader(http.StatusOK)
-	if _,err = fmt.Fprint(w, string(marshaled[:])); err != nil {
-		log.Error(err)
-	}
+	Respond(w, block, err)
 }

--- a/handlers/v1/block_handler_test.go
+++ b/handlers/v1/block_handler_test.go
@@ -23,7 +23,7 @@ func TestBlockHeaderHandler_ServeHTTP(t *testing.T) {
 			Tickets:               [][]byte{[]byte("ticket1")},
 			ElectionProof:         []byte("electionproof"),
 			Parents:               []cid.Cid{test.RequireTestCID(t, []byte("parent1"))},
-			ParentWeight:          *big.NewInt(1234),
+			ParentWeight:          big.NewInt(1234),
 			Height:                34343,
 			ParentStateRoot:       test.RequireTestCID(t, []byte("stateroot")),
 			ParentMessageReceipts: test.RequireTestCID(t, []byte("receipts")),
@@ -52,20 +52,20 @@ func TestBlockHeaderHandler_ServeHTTP(t *testing.T) {
 		var actual types.Block
 		require.NoError(t, json.Unmarshal(body, &actual))
 		assert.True(t, actual.ID.Equals(tb.ID))
-		assert.Equal(t, "block", tb.Kind)
-		assert.Equal(t, "blockHeader", tb.Header.Kind)
-		assert.Equal(t, actual.Header.Miner, tb.Header.Miner)
-		assert.Equal(t, actual.Header.Tickets[0], tb.Header.Tickets[0])
-		assert.Equal(t, actual.Header.ElectionProof, tb.Header.ElectionProof)
+		assert.Equal(t, "block", actual.Kind)
+		assert.Equal(t, "blockHeader", actual.Header.Kind)
+		assert.Equal(t, tb.Header.Miner, actual.Header.Miner)
+		assert.Equal(t, tb.Header.Tickets[0], actual.Header.Tickets[0])
+		assert.Equal(t, tb.Header.ElectionProof, actual.Header.ElectionProof)
 		assert.True(t, tb.Header.Parents[0].Equals(actual.Header.Parents[0]))
-		assert.Equal(t, actual.Header.ParentWeight, tb.Header.ParentWeight)
-		assert.Equal(t, actual.Header.Height, tb.Header.Height)
+		assert.Equal(t, tb.Header.ParentWeight, actual.Header.ParentWeight)
+		assert.Equal(t, tb.Header.Height, actual.Header.Height)
 		assert.True(t, tb.Header.ParentStateRoot.Equals(actual.Header.ParentStateRoot))
 		assert.True(t, tb.Header.ParentMessageReceipts.Equals(actual.Header.ParentMessageReceipts))
 		assert.True(t, tb.Header.Messages.Equals(actual.Header.Messages))
-		assert.Equal(t, actual.Header.BLSAggregate, tb.Header.BLSAggregate)
-		assert.Equal(t, actual.Header.Timestamp, tb.Header.Timestamp)
-		assert.Equal(t, actual.Header.BlockSig, tb.Header.BlockSig)
+		assert.Equal(t, tb.Header.BLSAggregate, actual.Header.BLSAggregate)
+		assert.Equal(t, tb.Header.Timestamp, actual.Header.Timestamp)
+		assert.Equal(t, tb.Header.BlockSig, actual.Header.BlockSig)
 	})
 
 }

--- a/handlers/v1/node_handler.go
+++ b/handlers/v1/node_handler.go
@@ -1,8 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/carbonfive/go-filecoin-rest-api/types"
@@ -14,21 +12,6 @@ type NodeHandler struct {
 }
 
 func (nid *NodeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	var marshaled []byte
 	node, err := nid.Callback()
-
-	if err != nil {
-		marshaled = types.MarshalErrors([]string{err.Error()})
-	} else {
-		node.Kind= "node"
-		if marshaled, err = json.Marshal(node); err != nil {
-			log.Error(err)
-			return
-		}
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _,err = fmt.Fprint(w, string(marshaled[:])); err != nil {
-		log.Error(err)
-	}
+	Respond(w, node, err)
 }

--- a/handlers/v1/respond.go
+++ b/handlers/v1/respond.go
@@ -1,0 +1,28 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/carbonfive/go-filecoin-rest-api/types"
+)
+
+func Respond(w http.ResponseWriter, result interface{}, cberr error) {
+	var marshaled []byte
+	var err error
+
+	if cberr != nil {
+		marshaled = types.MarshalErrors([]string{cberr.Error()})
+	} else {
+		if marshaled, err = json.Marshal(result); err != nil {
+			log.Error(err)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	if _, err := fmt.Fprint(w, string(marshaled[:])); err != nil {
+		log.Error(err)
+	}
+}

--- a/handlers/v1/respond_test.go
+++ b/handlers/v1/respond_test.go
@@ -1,0 +1,33 @@
+package v1_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v1 "github.com/carbonfive/go-filecoin-rest-api/handlers/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRespond(t *testing.T) {
+	t.Run("sets status code and serializes the result", func(t *testing.T) {
+		type TestResult struct {
+			Data string
+		}
+
+		rw := httptest.NewRecorder()
+		v1.Respond(rw, &TestResult{"abcd"}, nil)
+
+		assert.Equal(t, http.StatusOK, rw.Code)
+		assert.Equal(t, `{"Data":"abcd"}`, rw.Body.String())
+	})
+
+	t.Run("responds with serialized errors", func(t *testing.T) {
+		rw := httptest.NewRecorder()
+		v1.Respond(rw, nil, errors.New("boom"))
+
+		assert.Equal(t, http.StatusOK, rw.Code)
+		assert.Equal(t, `{"errors":["boom"]}`, rw.Body.String())
+	})
+}

--- a/types/actors.go
+++ b/types/actors.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"math/big"
 
 	"github.com/ipfs/go-cid"
@@ -18,7 +19,14 @@ type Actor struct {
 	Address   string                               `json:"address,omitempty"`
 	Code      cid.Cid                              `json:"code,omitempty"`
 	Nonce     uint64                               `json:"nonce,omitempty"`
-	Balance   big.Int                              `json:"balance,omitempty"`
+	Balance   *big.Int                             `json:"balance,omitempty"`
 	Exports   map[string]readableFunctionSignature `json:"exports,omitempty"` // exports by function name
 	Head      cid.Cid                              `json:"head,omitempty"`
+}
+
+func (o Actor) MarshalJSON() ([]byte, error) {
+	type alias Actor
+	out := alias(o)
+	out.Kind = "actor"
+	return json.Marshal(out)
 }

--- a/types/block_header.go
+++ b/types/block_header.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"math/big"
 
 	"github.com/ipfs/go-cid"
@@ -20,7 +21,7 @@ type BlockHeader struct {
 	Tickets               [][]byte  `json:"tickets,omitempty"`
 	ElectionProof         []byte    `json:"electionProof,omitempty"`
 	Parents               []cid.Cid `json:"parents,omitempty"`
-	ParentWeight          big.Int   `json:"parentWeight,omitempty"`
+	ParentWeight          *big.Int  `json:"parentWeight,omitempty"`
 	Height                uint64    `json:"height,omitempty"`
 	ParentStateRoot       cid.Cid   `json:"parentStateRoot,omitempty"`
 	ParentMessageReceipts cid.Cid   `json:"parentMessageReceipts,omitempty"`
@@ -28,4 +29,18 @@ type BlockHeader struct {
 	BLSAggregate          []byte    `json:"blsAggregate,omitempty"`
 	Timestamp             uint64    `json:"timestamp,omitempty"`
 	BlockSig              []byte    `json:"blockSig,omitempty"`
+}
+
+func (o Block) MarshalJSON() ([]byte, error) {
+	type alias Block
+	out := alias(o)
+	out.Kind = "block"
+	return json.Marshal(out)
+}
+
+func (o BlockHeader) MarshalJSON() ([]byte, error) {
+	type alias BlockHeader
+	out := alias(o)
+	out.Kind = "blockHeader"
+	return json.Marshal(out)
 }

--- a/types/node.go
+++ b/types/node.go
@@ -1,23 +1,30 @@
 package types
 
+import "encoding/json"
 
 // Protocol contains protocol-related settings for a Filecoin node
 type Protocol struct {
-	AutosealInterval uint64 `json:"autosealInterval,omitempty"`
-	SectorSizes []uint64 `json:"sectorSizes,omitempty"`
+	AutosealInterval uint64   `json:"autosealInterval,omitempty"`
+	SectorSizes      []uint64 `json:"sectorSizes,omitempty"`
 }
 
 // BitswapStats contains Bitswap related stats for a Filecoin node
 type BitswapStats struct{}
 
-
 // Node contains the Node level Filecoin information
 type Node struct {
-	Kind string `json:"node,required"`
-	Id string `json:"id,omitempty"`
-	Addresses []string `json:"addresses,omitempty"`
-	Version string `json:"version,omitempty"`
-	Commit string `json:"commit,omitempty"`
-	Protocol Protocol `json:"protocol,omitempty"`
+	Kind         string       `json:"node,required"`
+	Id           string       `json:"id,omitempty"`
+	Addresses    []string     `json:"addresses,omitempty"`
+	Version      string       `json:"version,omitempty"`
+	Commit       string       `json:"commit,omitempty"`
+	Protocol     Protocol     `json:"protocol,omitempty"`
 	BitswapStats BitswapStats `json:"bitswapStats,omitempty"`
+}
+
+func (n Node) MarshalJSON() ([]byte, error) {
+	type alias Node
+	out := alias(n)
+	out.Kind = "node"
+	return json.Marshal(out)
 }


### PR DESCRIPTION
## Summary
* Add a new `v1.Respond()` method, which handles responding for the various handlers
* Move marshaling concerns into the respective types
* Converted over to `*big.Int` from `big.Int` for serialization.